### PR TITLE
Use boolean feature to indicate a passing failure

### DIFF
--- a/spec/matest_specs/failing_spec.rb
+++ b/spec/matest_specs/failing_spec.rb
@@ -2,6 +2,6 @@ scope do
   let(:a) { true }
   spec do
     @b = false
-    a == @b
+    !(a == @b)
   end
 end


### PR DESCRIPTION
One advantage of using natural assertions is that the programmer can see
at a glance when a spec is written to fail. When we "expect" something
to fail, we ought to flip the bit so the test passes. This
(mind-bendingly) asserts that a failure would occur without the
bit-flip.

If `x=2` and `y=3`, we might want to test a failure like so:

~~~~ruby
scope do
  let(:x) { 2 }
  spec do
    y = 3
    x == y
  end
end
~~~~

The problem here is that we have to know when our test output says this
fails, it was actually a success. I don't want to have to think when I
look at my test output. I propose a convention of wrapping the failing
assertion expression and prepending a `not` operator.

~~~~ruby
scope do
  let(:x) { 2 }
  spec do
    y = 3
    !(x == y)
  end
end
~~~~

Now, when we run the tests, we get a passing failure spec. When we read
the test code, the intention of failing is obvious if we look inside the
parends. We no longer have to keep state in our head about the number of
"correctly failing" specs we've written for our suite.